### PR TITLE
Use execFile to fix command injection CVE-2020-28437

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -1,6 +1,6 @@
-var exec = require('child_process').exec
+var execFile = require('child_process').execFile;
 module.exports = function(app, cb) {
-  exec('heroku config --app ' + app, function(err, stdout) {
+  execFile(`heroku`, ["config", "--app", app] , function(err, stdout) {
     if(err) return cb(err);
     var config = {}
     var lines = stdout.split('\n')


### PR DESCRIPTION
Hello, this pull request fixes [CVE-2020-28437](https://nvd.nist.gov/vuln/detail/CVE-2020-28437) command injection vulnerability. The attack is dependent on escaping the `heroku` shell command in `get.js` to execute a second command. By using execFile we are able to specify the command and the shell command can't be escaped.